### PR TITLE
Upgrade default model from GPT-4o to GPT-5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+DFT-Agent is an LLM-powered agent system for materials research and DFT (Density Functional Theory) calculations. It uses LangGraph for agent orchestration and provides both API and Streamlit UI interfaces.
+
+## Key Commands
+
+### Development Setup
+```bash
+# Install dependencies using uv (preferred)
+uv sync
+
+# Or using pip
+pip install -e .
+```
+
+### Running the Application
+```bash
+# Start both API service and Streamlit frontend
+./scripts/run.sh
+
+# Or run components individually:
+# API Service
+python backend/run_service.py
+
+# Streamlit Frontend  
+streamlit run frontend/app.py
+
+# Stop all services
+./scripts/stop.sh
+```
+
+### Code Quality
+```bash
+# Run linting with ruff
+ruff check backend/
+ruff format backend/
+
+# Run tests (pytest is installed as dev dependency)
+pytest
+```
+
+### LangGraph Development
+```bash
+# Deploy agent using LangGraph CLI
+langgraph up
+
+# Test agent locally
+python backend/run_agent.py
+```
+
+## Architecture
+
+### Backend Structure
+- **backend/agents/**: LangGraph agent implementations
+  - `agent_manager.py`: Registry of available agents
+  - `library/chatbot.py`: Main chatbot agent graph
+  - `tools.py`: Agent tools (calculator, python_repl)
+  - `llm.py`: LLM provider configuration
+  
+- **backend/api/**: FastAPI application
+  - REST endpoints for agent interaction
+  - WebSocket support for streaming responses
+  
+- **backend/core/**: Core data models and types
+  
+- **backend/utils/**: Utility functions and helpers
+
+### Frontend
+- **frontend/app.py**: Streamlit application for user interface
+- Connects to backend API for agent interactions
+
+### Configuration
+- Environment variables loaded from `.env` file
+- Settings centralized in `backend/settings.py`
+- Supports multiple LLM providers: OpenAI, Groq, HuggingFace, Ollama
+- Materials Project API integration via MP_API_KEY
+
+## LLM Configuration
+
+The system supports multiple LLM providers configured via environment variables:
+- `OPENAI_API_KEY`: For OpenAI models
+- `GROQ_API_KEY`: For Groq models  
+- `HF_API_KEY`: For HuggingFace models
+- `OLLAMA_MODEL`: For local Ollama models
+- `DEFAULT_MODEL`: Set the default model to use
+
+## Development Notes
+
+- Python 3.12 required (enforced in pyproject.toml)
+- Uses `uv` for package management (see uv.lock)
+- Ruff configured for linting with line length 90
+- LangGraph agents defined in `langgraph.json`
+- Docker Compose available for containerized deployment

--- a/backend/agents/llm.py
+++ b/backend/agents/llm.py
@@ -21,6 +21,7 @@ _MODEL_TABLE = {
     FakeModelName.FAKE: "fake",
     OpenAIModelName.GPT_4O: "gpt-4o",
     OpenAIModelName.GPT_4O_MINI: "gpt-4o-mini",
+    OpenAIModelName.GPT_5: "gpt-5",
     OllamaModelName.OLLAMA_GENERIC: "ollama",
     GroqModelName.LLAMA_31_8B: "llama-3.1-8b-instant",
     GroqModelName.LLAMA_33_70B: "llama-3.3-70b-versatile",
@@ -41,9 +42,11 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
         raise ValueError(f"Unsupported model: {model_name}")
 
     if model_name in OpenAIModelName:
+        # GPT-5 only supports default temperature (1.0)
+        temp = 1.0 if model_name == OpenAIModelName.GPT_5 else 0.5
         return ChatOpenAI(
             model=api_model_name,
-            temperature=0.5,
+            temperature=temp,
             streaming=True,
             api_key=settings.OPENAI_API_KEY.get_secret_value()
             if settings.OPENAI_API_KEY

--- a/backend/api/endpoints/agent.py
+++ b/backend/api/endpoints/agent.py
@@ -59,6 +59,7 @@ def _parse_input(user_input: UserInput) -> tuple[dict[str, Any], UUID]:
         "config": RunnableConfig(
             configurable=configurable,
             run_id=run_id,
+            recursion_limit=50,
         ),
     }
     return kwargs, run_id

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -15,6 +15,7 @@ class OpenAIModelName(StrEnum):
 
     GPT_4O_MINI = "gpt-4o-mini"
     GPT_4O = "gpt-4o"
+    GPT_5 = "gpt-5"
 
 
 class GroqModelName(StrEnum):

--- a/backend/core/schema.py
+++ b/backend/core/schema.py
@@ -47,8 +47,8 @@ class UserInput(BaseModel):
     model: SerializeAsAny[AllModelEnum] | None = Field(
         title="Model",
         description="LLM Model to use for the agent.",
-        default=OpenAIModelName.GPT_4O,
-        examples=[OpenAIModelName.GPT_4O_MINI, OpenAIModelName.GPT_4O],
+        default=OpenAIModelName.GPT_5,
+        examples=[OpenAIModelName.GPT_4O_MINI, OpenAIModelName.GPT_4O, OpenAIModelName.GPT_5],
     )
     thread_id: str | None = Field(
         description="Thread ID to persist and continue a multi-turn conversation.",

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     USE_FAKE_MODEL: bool = False
 
     # If DEFAULT_MODEL is None, it will be set in model_post_init
-    DEFAULT_MODEL: AllModelEnum | None = OpenAIModelName.GPT_4O  # type: ignore[assignment]
+    DEFAULT_MODEL: AllModelEnum | None = OpenAIModelName.GPT_5  # type: ignore[assignment]
     AVAILABLE_MODELS: set[AllModelEnum] = set()  # type: ignore[assignment]
 
     MP_API_KEY: SecretStr | None = None
@@ -72,7 +72,7 @@ class Settings(BaseSettings):
             match provider:
                 case Provider.OPENAI:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = OpenAIModelName.GPT_4O
+                        self.DEFAULT_MODEL = OpenAIModelName.GPT_5
                     self.AVAILABLE_MODELS.update(set(OpenAIModelName))
                 case Provider.GROQ:
                     if self.DEFAULT_MODEL is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12, <3.13"
 dependencies = [
     "ase",
     "beautifulsoup4",
-    "duckduckgo-search",
+    "ddgs",
     "fastapi",
     "google-api-python-client",
     "google-auth-httplib2",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -442,13 +442,27 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/ff/a6bb3bb2bf363530c07d4a8b809a051ce2f8fd28f5cafb2c7d3e7832847e/ddgs-9.5.5.tar.gz", hash = "sha256:9a09aa9ba24173d14321137c8c1bc54040ed0bf3bad956cb2f9feeda77968770", size = 33560, upload-time = "2025-09-01T13:25:14.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/aa/0ca4b396a3940a04120679e0c1d2fce534018ca90d92d8a83115f05f1263/ddgs-9.5.5-py3-none-any.whl", hash = "sha256:01fc8017a653ad16501bd8ac9fedcd29291f6500b1f8a7e92a916cdad7fc2fa2", size = 37922, upload-time = "2025-09-01T13:25:13.337Z" },
+]
+
+[[package]]
 name = "dft-agent"
 version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "ase" },
     { name = "beautifulsoup4" },
-    { name = "duckduckgo-search" },
+    { name = "ddgs" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
@@ -504,7 +518,7 @@ dev = [
 requires-dist = [
     { name = "ase" },
     { name = "beautifulsoup4" },
-    { name = "duckduckgo-search" },
+    { name = "ddgs" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
@@ -572,20 +586,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
-]
-
-[[package]]
-name = "duckduckgo-search"
-version = "8.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "lxml" },
-    { name = "primp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Current default model is gpt-4o which is both less capable and more expensive than gpt-5. This PR also adds a CLAUDE.MD generated by Claude 4.1 Opus for those of us using Claude Code.
- Added GPT_5 model support to OpenAIModelName enum
- Updated model table mapping for GPT-5
- Changed default model to GPT-5 across settings and schema
- Fixed temperature parameter for GPT-5 (only supports default 1.0)
- Added CLAUDE.md documentation file

🤖 Generated with [Claude Code](https://claude.ai/code)