### PR TITLE
feat(agent): mention local datasets directory in system prompt

### DIFF
--- a/backend/agents/library/chatbot.py
+++ b/backend/agents/library/chatbot.py
@@ -52,6 +52,7 @@ tools = [web_search, calculator, python_repl]
 current_date = datetime.now().strftime("%B %d, %Y")
 images_dir = f"{settings.ROOT_PATH}/data/images"
 Path(images_dir).mkdir(parents=True, exist_ok=True)
+datasets_dir = f"{settings.ROOT_PATH}/data/raw_data"
 
 instructions = f"""
     You are a helpful chat assistant with the ability to search the web and use other tools.
@@ -69,6 +70,8 @@ instructions = f"""
     - Use Python REPL tool for data analysis and visualization tasks.
     - If Python REPL shows error fix the error in code and run again, if you are failing more than 3 times give up.
     - For data processing and analysis, use pandas library.
+    - Local datasets are available at: {datasets_dir}
+    - Load datasets with absolute paths via pandas, e.g., `import pandas as pd; from pathlib import Path; df = pd.read_csv(Path("{datasets_dir}") / "file.csv")`. Prefer read-only access; do not move or rename source files.
     - For charts generation, use seaborn or matplotlib.
     - ALWAYS save the plots/charts into the following folder: {images_dir}
     - Only include markdown-formatted links to citations used in your response. Only include one


### PR DESCRIPTION
This PR updates the chatbot system prompt to make local datasets discoverable and easy to load from Python REPL.\n\nChanges\n- Add `datasets_dir = f"{settings.ROOT_PATH}/data/raw_data"` next to the existing `images_dir`.\n- Add guidance to the prompt that local datasets live under that path.\n- Include a pandas example showing how to load files using an absolute path: `df = pd.read_csv(Path("{datasets_dir}") / "file.csv")`.\n- Encourage read-only access and avoiding moving/renaming source files.\n\nWhy\n- Ensures the agent reliably accesses files under `data/raw_data` regardless of CWD.\n- Reduces friction when users ask the agent to analyze local datasets.\n\nVerification\n1. Restart the local service (`scripts/stop.sh && scripts/run.sh`).\n2. In the chat, ask to list files under the datasets dir, e.g. via Python REPL: \n   `from pathlib import Path; p = Path("/data/raw_data"); print([str(x) for x in p.rglob('*')][:10])` (replace path as needed).\n3. Load a sample file with pandas using the example in the prompt and ensure it succeeds.\n\nNotes\n- Existing behavior for image saving (`data/images`) is unchanged.\n- No changes to API or configuration surface.