### PR TITLE
Add adsorption database benchmarking 

### DIFF
--- a/backend/agents/library/dft_agent/tool_registry.py
+++ b/backend/agents/library/dft_agent/tool_registry.py
@@ -37,6 +37,13 @@ from backend.agents.dft_tools import (
     verify_job_submission,
 )
 
+# Import adsorption data search tools from tools.py
+from backend.agents.tools import (
+    load_local_adsorption_data,
+    search_adsorption_data,
+    list_available_datasets,
+)
+
 TOOL_REGISTRY: dict[str, Tool] = {
     # Structure generation and manipulation
     "generate_bulk": generate_bulk,
@@ -68,6 +75,10 @@ TOOL_REGISTRY: dict[str, Tool] = {
     "query_calculations": query_calculations,
     "export_results": export_results,
     "search_similar_calculations": search_similar_calculations,
+    # Adsorption data search tools
+    "load_local_adsorption_data": load_local_adsorption_data,
+    "search_adsorption_data": search_adsorption_data,
+    "list_available_datasets": list_available_datasets,
     # SLURM job management
     "generate_slurm_script": generate_slurm_script,
     "submit_slurm_job": submit_slurm_job,

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -102,39 +102,11 @@ def load_local_adsorption_data(dataset_name: str = "CPD_H") -> Dict[str, Any]:
 
 
 """
-ADSORPTION DATA QUERYING FIXES - September 2025
+Adsorption Database Search Tools
 
-This function was updated to fix critical bugs in hydrogen adsorption data querying
-that prevented proper searching across different datasets with varying data structures.
-
-KEY FIXES IMPLEMENTED:
-
-1. DATASET STRUCTURE COMPATIBILITY:
-   - Problem: jp4c06194_SI dataset stores adsorbate as string ("H") while CPD_H 
-     stores it as object ({"formula": "H"}), causing 0 records returned
-   - Solution: Added flexible adsorbate parsing to handle both formats:
-     * isinstance(adsorbate_data, dict) → extract 'formula' field
-     * string format → use directly
-   - Impact: jp4c06194_SI now correctly returns 11 Pt-H records instead of 0
-
-2. ROBUST ERROR HANDLING:
-   - Added type checking and fallback for malformed adsorbate data
-   - Graceful handling of missing fields across different JSON schemas
-   - Prevents crashes when datasets have inconsistent structures
-
-3. VERIFIED FUNCTIONALITY:
-   - CPD_H: 2,872 total records, proper H-species filtering
-   - jp4c06194_SI: 281 total records, 11 Pt-H matches (avg: -0.531 eV)
-   - OC2020_H: Structured dataset with consistent object format
-
-TESTING STATUS:
-✅ All three datasets now searchable via search_adsorption_data()
-✅ Hydrogen adsorption queries work across different data schemas
-✅ Web interface integration confirmed functional
-✅ Changes committed and deployed to main branch
-
-USAGE: This function now reliably queries hydrogen adsorption energies across
-all available datasets regardless of their internal JSON structure differences.
+These tools enable benchmarking of DFT calculations against literature databases.
+Supports searching across multiple datasets with different data formats for validation
+of calculated adsorption energies.
 """
 @tool
 def search_adsorption_data(
@@ -169,11 +141,11 @@ def search_adsorption_data(
         # Check adsorbate
         if adsorbate:
             adsorbate_data = record.get('adsorbate', '')
-            # FIX: Handle both object format (CPD_H) and string format (jp4c06194_SI)
+            # Handle both object format and string format across datasets
             if isinstance(adsorbate_data, dict):
-                formula = adsorbate_data.get('formula', '')  # Object format: {"formula": "H"}
+                formula = adsorbate_data.get('formula', '')
             else:
-                formula = str(adsorbate_data)  # String format: "H"
+                formula = str(adsorbate_data)
             if not formula or adsorbate not in formula:
                 continue
             

--- a/backend/run_service.py
+++ b/backend/run_service.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 if __name__ == "__main__":
     uvicorn.run(
-        "api:app",
+        "backend.api.main:app",
         host=settings.HOST,
         port=settings.PORT,
         reload=settings.is_dev(),


### PR DESCRIPTION
### Summary

1. Added adsorption data search tools 

- `load_local_adsorption_data`, `search_adsorption_data`, `list_available_datasets`

2. Allow literature validation of DFT calculations by comparing the calculated adsorption energies with our database.

Addressing #4 